### PR TITLE
Removed /learning/ from import statements to allow build with controller...

### DIFF
--- a/controllers/persons.go
+++ b/controllers/persons.go
@@ -2,7 +2,7 @@ package controllers
 
 import (
 	"github.com/albrow/go-data-parser"
-	"github.com/albrow/learning/peeps-negroni/models"
+	"github.com/albrow/peeps-negroni/models"
 	"github.com/albrow/zoom"
 	"github.com/gorilla/mux"
 	"github.com/unrolled/render"

--- a/server.go
+++ b/server.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	"github.com/albrow/learning/peeps-negroni/controllers"
-	"github.com/albrow/learning/peeps-negroni/models"
-	"github.com/albrow/negroni-json-recovery"
+	"github.com/albrow/peeps-negroni/controllers"
+	"github.com/albrow/peeps-negroni/models"
+
 	"github.com/codegangsta/negroni"
 	"github.com/gorilla/mux"
+
+	"github.com/albrow/negroni-json-recovery"
 )
 
 func main() {


### PR DESCRIPTION
...s and models folders in repo

Looks like /learning/ was a local directory, but to point at controllers and models directories in repo, import statements changed. May be trivial but will allow easier clone and build.
