### PR TITLE
remove error handling from zoom.Init call

### DIFF
--- a/models/init.go
+++ b/models/init.go
@@ -5,9 +5,8 @@ import (
 )
 
 func Init() error {
-	if err := zoom.Init(&zoom.Configuration{Database: 1}); err != nil {
-		return err
-	}
+	zoom.Init(&zoom.Configuration{Database: 1})
+
 	var err error
 	People, err = zoom.Register(&Person{})
 	if err != nil {


### PR DESCRIPTION
App didn't build because of API change, after `go get` I've got message

```
zoom.Init(&zoom.Configuration literal) used as value
```
